### PR TITLE
Use usleep for rate limiting delay

### DIFF
--- a/proxy_checker.php
+++ b/proxy_checker.php
@@ -203,8 +203,8 @@ class ProxyChecker {
             
             // Rate limiting: delay 1.5 giây giữa các request (40 req/min)
             if ($processedCount < count($queueProxies)) {
-                $this->log("Rate limiting: sleeping 1.5 seconds...");
-                sleep(1.5);
+                $this->log("Rate limiting: sleeping 1.5 seconds (using usleep)...");
+                usleep(1500000);
             }
         }
         


### PR DESCRIPTION
## Summary
- switch the rate limiting delay in ProxyChecker::processQueue to use usleep for microsecond precision
- update the rate limiting log message to reflect the use of usleep

## Testing
- php -r '$_GET["action"] = "check"; include "proxy_checker.php";'

------
https://chatgpt.com/codex/tasks/task_b_68ca384cafcc8331b3b3ce8e716bee6d