### PR TITLE
Pass event to checkbox handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -1875,7 +1875,7 @@
         }
 
         // Handle checkbox logic
-        function handleCheckboxChange(dropdownId) {
+        function handleCheckboxChange(dropdownId, event) {
             const dropdown = document.getElementById(dropdownId + '-dropdown');
             const allCheckbox = dropdown.querySelector('input[type="checkbox"][id*="all"]');
             const otherCheckboxes = dropdown.querySelectorAll('input[type="checkbox"]:not([id*="all"])');
@@ -1913,7 +1913,7 @@
         
         function handleCheckboxChangeWrapper(event) {
             const dropdownId = event.target.closest('.dropdown').id.replace('-dropdown', '');
-            handleCheckboxChange(dropdownId);
+            handleCheckboxChange(dropdownId, event);
         }
         
         // Initialize the application


### PR DESCRIPTION
## Summary
- update `handleCheckboxChange` to accept the event object and rely on its target explicitly
- ensure the checkbox change wrapper forwards the event object to the handler

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ca35c8dd748331bf307779d329d969