### PR TITLE
Add proxy input validation

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -1,14 +1,74 @@
 <?php
 // proxy.php - Auto trigger version
-if (isset($_POST['proxy'])) {
-    $data = $_POST['proxy'];
-} else {
+
+function isValidProxy(string $proxy): bool
+{
+    if ($proxy === '') {
+        return false;
+    }
+
+    $parts = explode(':', $proxy, 2);
+    if (count($parts) !== 2) {
+        return false;
+    }
+
+    [$host, $port] = array_map('trim', $parts);
+
+    if ($host === '' || $port === '') {
+        return false;
+    }
+
+    if (!ctype_digit($port)) {
+        return false;
+    }
+
+    $portNumber = (int) $port;
+    if ($portNumber < 1 || $portNumber > 65535) {
+        return false;
+    }
+
+    if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
+        return true;
+    }
+
+    return (bool) filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME);
+}
+
+if (!isset($_POST['proxy'])) {
     http_response_code(400);
     exit('no data');
 }
 
+$rawInput = $_POST['proxy'];
+$rawItems = [];
+
+if (is_array($rawInput)) {
+    $rawItems = $rawInput;
+} else {
+    $rawItems = preg_split('/[\r\n]+/', (string) $rawInput);
+}
+
+$validProxies = [];
+
+foreach ($rawItems as $item) {
+    $proxy = trim((string) $item);
+
+    if ($proxy === '') {
+        continue;
+    }
+
+    if (isValidProxy($proxy)) {
+        $validProxies[] = $proxy;
+    }
+}
+
+if (empty($validProxies)) {
+    http_response_code(400);
+    exit('invalid proxy format');
+}
+
 $file = __DIR__ . '/proxy_8080.txt';
-file_put_contents($file, $data . PHP_EOL, FILE_APPEND | LOCK_EX);
+file_put_contents($file, implode(PHP_EOL, $validProxies) . PHP_EOL, FILE_APPEND | LOCK_EX);
 
 // ✅ TỰ ĐỘNG TRIGGER PROXY CHECKER NGAY LẬP TỨC
 try {


### PR DESCRIPTION
## Summary
- validate proxy submissions before appending them to the queue
- support multi-line proxy submissions while discarding invalid entries

## Testing
- php -l proxy.php

------
https://chatgpt.com/codex/tasks/task_b_68ca40edcf48833184f84e43d1759d9a